### PR TITLE
chore: added support for multiple sorting keys

### DIFF
--- a/label_studio/data_manager/models.py
+++ b/label_studio/data_manager/models.py
@@ -40,7 +40,7 @@ class ProjectViewMixin(models.Model):
         abstract = True
 
 # TODO: temporary fix: future maybe we can add them in frontend or just add them in DB
-project_with_fix_first_ordering_key=[5,6,7]
+projects_with_fixed_first_ordering_key=[5,6,7]
 class View(ViewBaseModel, ProjectViewMixin):
     def get_prepare_tasks_params(self, add_selected_items=False):
         # convert filters to PrepareParams structure

--- a/label_studio/data_manager/models.py
+++ b/label_studio/data_manager/models.py
@@ -39,7 +39,8 @@ class ProjectViewMixin(models.Model):
     class Meta:
         abstract = True
 
-
+# TODO: temporary fix: future maybe we can add them in frontend or just add them in DB
+project_with_fix_first_ordering_key=[5,6,7]
 class View(ViewBaseModel, ProjectViewMixin):
     def get_prepare_tasks_params(self, add_selected_items=False):
         # convert filters to PrepareParams structure
@@ -60,6 +61,11 @@ class View(ViewBaseModel, ProjectViewMixin):
         ordering = self.ordering
         if not ordering:
             ordering = []  # default empty json field is dict, but we need list
+        
+        print("self.project_id.",self.project_id)
+        if self.project_id in project_with_fix_first_ordering_key:
+            ordering.insert(0, "tasks:data.Conversation id")  
+        
 
         selected_items = None
         if add_selected_items and self.selected_items:

--- a/label_studio/data_manager/models.py
+++ b/label_studio/data_manager/models.py
@@ -63,7 +63,7 @@ class View(ViewBaseModel, ProjectViewMixin):
             ordering = []  # default empty json field is dict, but we need list
         
         print("self.project_id.",self.project_id)
-        if self.project_id in project_with_fix_first_ordering_key:
+        if self.project_id in projects_with_fixed_first_ordering_key:
             ordering.insert(0, "tasks:data.Conversation id")  
         
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Backend (Database)
- [x] Backend (API)
- [ ] Frontend



### Describe the reason for change
_(link to issue, supportive screenshots etc.)_



#### What does this fix?
_(if this is a bug fix)_



#### What is the new behavior?
_(if this is a breaking or feature change)_
1. It supports multiple sorting keys. Currently, the first key is fixed as 'Conversation ID' for predefined projects. However, to make it support dynamic multiple keys and convert the sorting dropdown into a multi-select, we have to make some changes to our frontend.

#### What is the current behavior?
_(if this is a breaking or feature change)_
You can pick an key to sort but for predefined projects it's always be group by `Conversation ID`


#### What libraries were added/updated?
_(list all with version changes)_
None


#### Does this change affect performance?
_(if so describe the impacts positive or negative)_
Maybe. Since it makes the DB query a bit more complicated, the more complicated the query, the more processing it has to do. However, for two keys at the moment, it won't be an issue.


#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_
None


#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [X] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

